### PR TITLE
pass container object to templateSelection function

### DIFF
--- a/src/js/select2/selection/placeholder.js
+++ b/src/js/select2/selection/placeholder.js
@@ -18,10 +18,9 @@ define([
     return placeholder;
   };
 
-  Placeholder.prototype.createPlaceholder = function (decorated, placeholder) {
-    var $placeholder = this.selectionContainer();
+  Placeholder.prototype.createPlaceholder = function (decorated, placeholder, $placeholder) {
 
-    $placeholder.html(this.display(placeholder));
+    $placeholder.html(this.display(placeholder,$placeholder));
     $placeholder.addClass('select2-selection__placeholder')
                 .removeClass('select2-selection__choice');
 
@@ -39,10 +38,11 @@ define([
     }
 
     this.clear();
-
-    var $placeholder = this.createPlaceholder(this.placeholder);
-
+    
+    var $placeholder = this.selectionContainer();
     this.$selection.find('.select2-selection__rendered').append($placeholder);
+    var $placeholder = this.createPlaceholder(this.placeholder,$placeholder);
+
   };
 
   return Placeholder;


### PR DESCRIPTION
Currently when templateSelection is called during placeholder rendering, container argument is null. Found that the container object is never passed into templateSelection function for the placeholder.
Fix allows modification to placeholder container or its parents during templateSelection call.

// before
...
templateSelection : function (data,container) {
  if(data.id == 0){ // place holder value?
    // container is undefined. code will break when someone tries to do something like;
    container.parent().parent().addClass('...');
  }
  ...
}

// after
...
templateSelection : function (data,container) {
  if(data.id == 0){ // place holder value?
    // container is appended to dom and dev can walk through the dom tree
    container.parent().parent().addClass('initial-state');
  }
  ...
}

This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- create placeholder container and append to dom tree before calling createPlaceholder
- pass placeholder container to templateSelection method
-

If this is related to an existing ticket, include a link to it as well.
